### PR TITLE
Spt 34 menu item wrapping

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export default class Drawer extends Component {
       ...target.props.style,
       transition: '.25s max-height linear',
       maxHeight,
-      overflow: 'auto'
+      overflow: 'hidden'
     };
     return cloneElement(target, { ref, onTransitionEnd, style }, ...(target.children || []));
     

--- a/index.js
+++ b/index.js
@@ -41,10 +41,10 @@ export default class Drawer extends Component {
     
       }
       oldTargetOnTransitionEnd();
-    }
-    
-    const maxHeight = drawer.state.isOpen ? (drawer.state.memoizedTargetHeight || '100vh') : 0;
-    
+    };
+  
+    const maxHeight = drawer.state.isOpen ? (drawer.state.memoizedTargetHeight || '9999px') : 0;
+  
     const style = {
       ...target.props.style,
       transition: '.25s max-height linear',

--- a/index.js
+++ b/index.js
@@ -2,22 +2,22 @@ import { Component, Children, cloneElement } from 'react';
 
 export default class Drawer extends Component {
   constructor(props) {
-      super(props);
-      const isOpen = !!Children
-        .map(props.children, child => child)
-        .filter(child => child.props && child.props.target)
-        .find(child => child.props.open);
-
-      this.state = {
-        isOpen,
-        memoizedTargetHeight: 0
-      };
+    super(props);
+    const isOpen = !!Children
+      .map(props.children, child => child)
+      .filter(child => child.props && child.props.target)
+      .find(child => child.props.open);
+    
+    this.state = {
+      isOpen,
+      memoizedTargetHeight: 0
+    };
   }
-
+  
   _handleTrigger() {
     this.setState({ isOpen: !this.state.isOpen });
   }
-
+  
   _upgradeTrigger(trigger) {
     const drawer = this;
     const oldTriggerOnClick = trigger.props.onClick || (() => {});
@@ -28,7 +28,7 @@ export default class Drawer extends Component {
     }
     return cloneElement(trigger, { onClick }, ...(trigger.children || []))
   }
-
+  
   _upgradeTarget(target) {
     const drawer = this;
     const ref = (t) => drawer._targetRef = t;
@@ -38,30 +38,31 @@ export default class Drawer extends Component {
       const height = Number.parseInt(window.getComputedStyle(drawer._targetRef).height, 10);
       if (height) {
         drawer.setState({ memoizedTargetHeight: height });
+    
       }
       oldTargetOnTransitionEnd();
     }
-
+    
     const maxHeight = drawer.state.isOpen ? (drawer.state.memoizedTargetHeight || '100vh') : 0;
-
+    
     const style = {
       ...target.props.style,
       transition: '.25s max-height linear',
       maxHeight,
       overflow: 'auto'
     };
-
     return cloneElement(target, { ref, onTransitionEnd, style }, ...(target.children || []));
-
+    
+    
   }
-
+  
   _close() {
     this.setState({isOpen: false});
   }
-
+  
   render() {
     const drawer = this;
-
+    
     const children = Children.map(drawer.props.children, (child) => {
       if (!child || !child.props) { return child; }
       if (child.props.trigger) {
@@ -71,9 +72,9 @@ export default class Drawer extends Component {
       }
       return child;
     });
-
+    
     const props = { ...drawer.props, open: drawer.state.isOpen, children };
-
+    
     if(drawer.props.closeOnBlur) {
       props.tabIndex=0;
       props.onBlur = drawer._close.bind(drawer);


### PR DESCRIPTION
## What this PR does
- Fixes word-wrapping of menu items by changing overflow to hidden, which prevents scroll-bar appearing within menu. This issue was only reproduced in Chrome 51, Windows 8, 1366 x 768 within browserstack.com
## How should this be manually tested?
- Pull branch SPT-34.
- npm link to IHv2
- Test for word-wrapping and scroll-bar in Windows 8, Chrome 51, display resolution 1366 x 768.
## What are the relevant tickets?
- SPT-34
